### PR TITLE
feat: open signcolumn by default in neovim

### DIFF
--- a/modules/cli/nvim/init.nvim
+++ b/modules/cli/nvim/init.nvim
@@ -97,6 +97,7 @@ set scrolloff=3
 set laststatus=2
 set list
 set hidden
+set signcolumn=yes
 
 " Relative Line Numbers
 set number


### PR DESCRIPTION
neovim gutter의 sign column을 기본으로 열어둡니다.